### PR TITLE
[wip] Implement IPC Upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipc-upstream"
+version = "0.1.0"
+dependencies = [
+ "cli-params 0.1.0",
+ "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
+ "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "upstream 0.1.0",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +920,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cli 0.1.0",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipc-upstream 0.1.0",
  "jsonrpc-core 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
  "jsonrpc-pubsub 9.0.0 (git+https://github.com/paritytech/jsonrpc.git)",
  "permissioning 0.1.0",

--- a/generic-proxy/Cargo.toml
+++ b/generic-proxy/Cargo.toml
@@ -15,6 +15,7 @@ tokio = "0.1"
 transports = { path = "../proxy/transports" }
 upstream = { path = "../plugins/upstream" }
 ws-upstream = { path = "../plugins/ws-upstream" }
+ipc-upstream = { path = "../plugins/ipc-upstream" }
 
 [[bin]]
 name = "rpc-proxy"

--- a/plugins/ipc-upstream/Cargo.toml
+++ b/plugins/ipc-upstream/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ipc-upstream"
+version = "0.1.0"
+authors = ["Tomasz Drwięga <tomusdrw@gmail.com>"]
+
+[dependencies]
+cli-params = { path = "../../proxy/cli-params" }
+jsonrpc-core = { git="https://github.com/paritytech/jsonrpc.git" }
+jsonrpc-pubsub = { git="https://github.com/paritytech/jsonrpc.git" }
+log = "0.4"
+serde_json = "1.0"
+tokio = "0.1"
+tokio-uds = "0.2.5"
+upstream = { path = "../upstream" }

--- a/plugins/ipc-upstream/Cargo.toml
+++ b/plugins/ipc-upstream/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ipc-upstream"
 version = "0.1.0"
 authors = ["Tomasz Drwięga <tomusdrw@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 cli-params = { path = "../../proxy/cli-params" }

--- a/plugins/ipc-upstream/src/config.rs
+++ b/plugins/ipc-upstream/src/config.rs
@@ -1,0 +1,24 @@
+//! IPC upstream configuration parameters.
+
+use cli_params;
+
+/// Configuration options of the IPC upstream
+pub enum Param {
+    /// Upstream URL
+    Path(String),
+}
+
+/// Returns all configuration parameters for IPC upstream.
+pub fn params() -> Vec<cli_params::Param<Param>> {
+    vec![
+        cli_params::Param::new(
+            "IPC upstream",
+            "upstream-ipc",
+            "Path to the IPC socket we should connect to.",
+            "/var/tmp/parity.ipc",
+            move |val: String| {
+                Ok(Param::Path(val))
+            },
+        )
+    ]
+}

--- a/plugins/ipc-upstream/src/lib.rs
+++ b/plugins/ipc-upstream/src/lib.rs
@@ -1,0 +1,233 @@
+//! IPC (JSON-RPC) Upstream Transport
+
+#![warn(missing_docs)]
+#![warn(unused_extern_crates)]
+
+extern crate cli_params;
+extern crate jsonrpc_core as rpc;
+extern crate jsonrpc_pubsub as pubsub;
+extern crate serde_json;
+extern crate tokio;
+extern crate tokio_uds;
+extern crate upstream;
+
+#[macro_use]
+extern crate log;
+
+pub mod config;
+
+use std::{
+    sync::{atomic, Arc},
+    io::{Error, ErrorKind}
+};
+use rpc::{
+    futures::{
+        self, Future, Sink, Stream,
+        sync::{mpsc, oneshot},
+    },
+};
+use upstream::{
+    Subscription,
+    helpers,
+    shared::{PendingKind, Shared},
+};
+use tokio_uds::UnixStream;
+use tokio::codec::{Framed, LinesCodec};
+
+struct IpcHandler {
+    shared: Arc<Shared>,
+}
+
+impl IpcHandler {
+    pub fn process_message(&self, message: String) -> impl Future<Item = (), Error = String> {
+      use self::futures::{IntoFuture, future::Either};
+
+      // First check if it's a notification for a subscription
+      if let Some(id) = helpers::peek_subscription_id(message.as_bytes()) {
+          return if let Some(stream) = self.shared.notify_subscription(&id, message) {
+              Either::A(stream)
+          } else {
+              warn!("Got notification for unknown subscription (id: {:?})", id);
+              Either::B(Ok(()).into_future())
+          }
+      }
+
+      // then check if it's one of the pending calls
+      if let Some(id) = helpers::peek_id(message.as_bytes()) {
+          if let Some((sink, kind)) = self.shared.remove_pending(&id) {
+              match kind {
+                  // Just a regular call, don't do anything else.
+                  PendingKind::Regular => {},
+                  // We have a subscription ID, register subscription.
+                  PendingKind::Subscribe(session, unsubscribe) => {
+                      let subscription_id = helpers::peek_result(message.as_bytes())
+                          .as_ref()
+                          .and_then(pubsub::SubscriptionId::parse_value);
+                      if let Some(subscription_id) = subscription_id {
+                          self.shared.add_subscription(subscription_id, session, unsubscribe);
+                      }
+                  },
+              }
+
+              trace!("Responding to (id: {:?}) with {:?}", id, message);
+              if let Err(err) = sink.send(message) {
+                  warn!("Sending a response to deallocated channel: {:?}", err);
+              }
+          } else {
+              warn!("Got response for unknown request (id: {:?})", id);
+          }
+      } else {
+          warn!("Got unexpected notification: {:?}", message);
+      }
+
+      Either::B(Ok(()).into_future())
+    }
+}
+
+/// IPC transport
+#[derive(Debug, Clone)]
+pub struct IPC {
+    id: Arc<atomic::AtomicUsize>,
+    path: String,
+    shared: Arc<Shared>,
+    write_sender: mpsc::UnboundedSender<String>,
+}
+
+impl IPC {
+    /// Create new IPC transport within existing Event Loop.
+    pub fn new(
+        runtime: &mut tokio::runtime::Runtime,
+        params: Vec<config::Param>,
+    ) -> Result<Self, String> {
+
+        let mut path = "/var/tmp/parity.ipc".to_string();
+
+        for p in params {
+            match p {
+                config::Param::Path(new_path) => {
+                    path = new_path;
+                }
+            }
+        }
+
+        println!("[IPC] Connecting to: {:?}", path);
+
+        let (write_sender, write_receiver) = mpsc::unbounded();
+        let shared = Arc::new(Shared::default());
+
+        let handler = IpcHandler {
+              shared: shared.clone(),
+        };
+
+        runtime.spawn(
+          UnixStream::connect(path.clone())
+          .and_then(move |client| {
+            let (sink, stream) = Framed::new(client, LinesCodec::new()).split();
+
+            let reader = stream.for_each(move |line| {
+                handler.process_message(String::from(line)).map_err(|_| Error::new(ErrorKind::Other, "Error processing message"))
+            });
+
+            let writer = sink.send_all(
+              write_receiver.map_err(|_| Error::new(ErrorKind::Other, "Error in mpsc receiver"))
+            );
+
+            writer.join(reader)
+          })
+          .map(|_| ())
+          .map_err(|err| {
+              error!("IpcError: {:?}", err);
+          })
+        );
+
+        Ok(Self {
+            id: Arc::new(atomic::AtomicUsize::new(1)),
+            path,
+            shared,
+            write_sender,
+        })
+    }
+
+    fn write_and_wait(&self, call: rpc::Call, response: Option<oneshot::Receiver<String>>) -> impl Future<Item = Option<rpc::Output>, Error = String>
+    {
+        let request = rpc::types::to_string(&call).expect("jsonrpc-core are infallible");
+        let result = self.write_sender
+            .unbounded_send(request)
+            .map_err(|e| format!("Error sending request: {:?}", e));
+
+        futures::done(result)
+            .and_then(|_| response.map_err(|e| format!("{:?}", e)))
+            .map(|out| out.and_then(|out| serde_json::from_str(&out).ok()))
+    }
+}
+
+// TODO [ToDr] Might be better to simply have one connection per subscription.
+// in case we detect that there is something wrong (i.e. the client disconnected)
+// we disconnect from the upstream as well and all the subscriptions are dropped automatically.
+impl upstream::Transport for IPC {
+    type Error = String;
+    type Future = Box<Future<Item = Option<rpc::Output>, Error = Self::Error> + Send>;
+
+    fn send(&self, call: rpc::Call) -> Self::Future {
+        trace!("Calling: {:?}", call);
+
+        // TODO [ToDr] Mangle ids per sender or just ensure atomicity
+        let rx = {
+            let id = helpers::get_id(&call);
+            self.shared.add_pending(id, PendingKind::Regular)
+        };
+
+        Box::new(self.write_and_wait(call, rx))
+    }
+
+    fn subscribe(
+        &self,
+        call: rpc::Call,
+        session: Option<Arc<pubsub::Session>>,
+        subscription: Subscription,
+    ) -> Self::Future {
+        let session = match session {
+            Some(session) => session,
+            None => {
+                return Box::new(futures::future::err("Called subscribe without session.".into()));
+            }
+        };
+
+        trace!("Subscribing to {:?}: {:?}", subscription, call);
+
+        // TODO [ToDr] Mangle ids per sender or just ensure atomicity
+        let rx = {
+            let ipc = self.clone();
+            let id = helpers::get_id(&call);
+            self.shared.add_pending(id, PendingKind::Subscribe(session, Box::new(move |subs_id| {
+                // Create unsubscribe request.
+                let call = rpc::Call::MethodCall(rpc::MethodCall {
+                    jsonrpc: Some(rpc::Version::V2),
+                    id: rpc::Id::Num(1),
+                    method: subscription.unsubscribe.clone(),
+                    params: rpc::Params::Array(vec![subs_id.into()]).into(),
+                });
+                ipc.unsubscribe(call, subscription.clone());
+            })))
+        };
+
+        Box::new(self.write_and_wait(call, rx))
+    }
+
+    fn unsubscribe(
+        &self,
+        call: rpc::Call,
+        subscription: Subscription,
+    ) -> Self::Future {
+
+        trace!("Unsubscribing from {:?}: {:?}", subscription, call);
+
+        // Remove the subscription id
+        if let Some(subscription_id) = helpers::get_unsubscribe_id(&call) {
+            self.shared.remove_subscription(&subscription_id);
+        }
+
+        // It's a regular RPC, so just send it
+        self.send(call)
+    }
+}

--- a/plugins/ipc-upstream/src/lib.rs
+++ b/plugins/ipc-upstream/src/lib.rs
@@ -3,16 +3,10 @@
 #![warn(missing_docs)]
 #![warn(unused_extern_crates)]
 
-extern crate cli_params;
-extern crate jsonrpc_core as rpc;
-extern crate jsonrpc_pubsub as pubsub;
-extern crate serde_json;
-extern crate tokio;
-extern crate tokio_uds;
-extern crate upstream;
+use jsonrpc_core as rpc;
+use jsonrpc_pubsub as pubsub;
 
-#[macro_use]
-extern crate log;
+use log::{warn, trace, error};
 
 pub mod config;
 

--- a/plugins/upstream/src/config.rs
+++ b/plugins/upstream/src/config.rs
@@ -10,6 +10,17 @@ use Subscription;
 pub enum Param {
     /// PublishSubscribe methods
     PubSubMethods(Vec<Subscription>),
+    /// Transport used to communicate upstream
+    UpstreamTransport(Transport)
+}
+
+/// Upstream transports to choose from
+#[derive(Clone, Debug)]
+pub enum Transport {
+  /// WebSocket
+  WebSocket,
+  /// IPC (Unix Domain Socket)
+  IPC
 }
 
 /// Returns all configuration parameters for WS upstream.
@@ -30,6 +41,21 @@ pub fn params() -> Vec<cli_params::Param<Param>> {
                 let config: Upstream = serde_json::from_reader(buf_file).map_err(|e| format!("Invalid JSON at {}: {:?}", path, e))?;
                 Ok(Param::PubSubMethods(config.pubsub_methods))
             },
+        ),
+        cli_params::Param::new(
+            "Upstream transport",
+            "upstream-transport",
+            "Define transport to use to communicate upstream. One of: ws, ipc.",
+            "ws",
+            move |transport: String| {
+              match transport.as_ref() {
+                "ws" => Ok(Param::UpstreamTransport(Transport::WebSocket)),
+                "ipc" => Ok(Param::UpstreamTransport(Transport::IPC)),
+                x => {
+                  Err(format!("Invalid upstream transport provided: {}. Must be one of: ws, ipc.", x))
+                }
+              }
+            },
         )
     ]
 }
@@ -41,6 +67,7 @@ pub fn add_subscriptions(params: &mut [Param], methods: Vec<Subscription>) {
             Param::PubSubMethods(ref mut m) => {
                 m.extend(methods.clone());
             }
+            _ => {}
         }
     }
 }

--- a/plugins/upstream/src/config.rs
+++ b/plugins/upstream/src/config.rs
@@ -9,18 +9,7 @@ use Subscription;
 #[derive(Clone, Debug)]
 pub enum Param {
     /// PublishSubscribe methods
-    PubSubMethods(Vec<Subscription>),
-    /// Transport used to communicate upstream
-    UpstreamTransport(Transport)
-}
-
-/// Upstream transports to choose from
-#[derive(Clone, Debug)]
-pub enum Transport {
-  /// WebSocket
-  WebSocket,
-  /// IPC (Unix Domain Socket)
-  IPC
+    PubSubMethods(Vec<Subscription>)
 }
 
 /// Returns all configuration parameters for WS upstream.
@@ -41,21 +30,6 @@ pub fn params() -> Vec<cli_params::Param<Param>> {
                 let config: Upstream = serde_json::from_reader(buf_file).map_err(|e| format!("Invalid JSON at {}: {:?}", path, e))?;
                 Ok(Param::PubSubMethods(config.pubsub_methods))
             },
-        ),
-        cli_params::Param::new(
-            "Upstream transport",
-            "upstream-transport",
-            "Define transport to use to communicate upstream. One of: ws, ipc.",
-            "ws",
-            move |transport: String| {
-              match transport.as_ref() {
-                "ws" => Ok(Param::UpstreamTransport(Transport::WebSocket)),
-                "ipc" => Ok(Param::UpstreamTransport(Transport::IPC)),
-                x => {
-                  Err(format!("Invalid upstream transport provided: {}. Must be one of: ws, ipc.", x))
-                }
-              }
-            },
         )
     ]
 }
@@ -67,7 +41,6 @@ pub fn add_subscriptions(params: &mut [Param], methods: Vec<Subscription>) {
             Param::PubSubMethods(ref mut m) => {
                 m.extend(methods.clone());
             }
-            _ => {}
         }
     }
 }

--- a/plugins/upstream/src/lib.rs
+++ b/plugins/upstream/src/lib.rs
@@ -91,6 +91,7 @@ impl<T> Middleware<T> {
         for p in params {
             match p {
                 config::Param::PubSubMethods(ref m) => pubsub_methods.extend(m.clone()),
+                _ => {}
             }
         }
 

--- a/plugins/upstream/src/lib.rs
+++ b/plugins/upstream/src/lib.rs
@@ -91,7 +91,6 @@ impl<T> Middleware<T> {
         for p in params {
             match p {
                 config::Param::PubSubMethods(ref m) => pubsub_methods.extend(m.clone()),
-                _ => {}
             }
         }
 

--- a/plugins/ws-upstream/src/lib.rs
+++ b/plugins/ws-upstream/src/lib.rs
@@ -111,7 +111,7 @@ pub struct WebSocket {
 impl WebSocket {
     /// Create new WebSocket transport within existing Event Loop.
     pub fn new(
-        runtime: &mut tokio::runtime::current_thread::Runtime,
+        runtime: &mut tokio::runtime::Runtime,
         params: Vec<config::Param>,
     ) -> Result<Self, String> {
 


### PR DESCRIPTION
This PR lets the proxy connect to Parity Ethereum via IPC socket. The path is provided by the `--upstream-ipc` flag.

Two things for which I need guidance:
- I added the argument `--upstream-transport=ws|ipc`; however currently it doesn't have any effect (need to manually comment/uncomment [here](https://github.com/axelchalon/jsonrpc-proxy/blob/ipc-upstream-2/generic-proxy/src/lib.rs#L97-L100)). `transport` needs to be set conditionally to either a `ws_upstream::WebSocket` or a `ipc_upstream::IPC`; it is then used when generating the `rpc::MetaIoHandler::with_middleware`. None of the ways I tried ended up working. How would you implement it? (The logic might also be better put in the *upstream* crate rather than in *generic-proxy*?)
- There is quite a bit of overlap between *ipc-upstream* and *ws-upstream*. Most notably their [`upstream::Transport` implementation](https://github.com/axelchalon/jsonrpc-proxy/blob/ipc-upstream-2/plugins/ipc-upstream/src/lib.rs#L164-L233) is the same. Should we make it the default implementation?