### PR TITLE
Make default port of TCP server different from websocket server

### DIFF
--- a/proxy/cli-params/src/lib.rs
+++ b/proxy/cli-params/src/lib.rs
@@ -35,7 +35,7 @@ pub struct Param<Exec> {
     /// Parameter default value
     pub default_value: String,
     /// Parameter parser
-    pub parser: Box<Parser<Executor=Exec>>,
+    pub parser: Box<dyn Parser<Executor=Exec>>,
 }
 
 impl<X> Param<X> {

--- a/proxy/transports/src/tcp.rs
+++ b/proxy/transports/src/tcp.rs
@@ -62,7 +62,7 @@ pub fn start<T, M, S>(
         Some(Arc::new(pubsub::Session::new(context.sender.clone()))).into()
     });
     // should be overwritten by parameters anyway
-    let mut address = "127.0.0.1:9945".parse().unwrap();
+    let mut address = "127.0.0.1:9955".parse().unwrap();
     // configure the server
     for p in params {
         builder = p.configure(&mut address, builder)?;


### PR DESCRIPTION
This fixes the error `Address already in use` when not supplying port for TCP server as argument.

Signed-off-by: lovesh <lovesh.bond@gmail.com>